### PR TITLE
Fix ShapelyDeprecationWarning

### DIFF
--- a/antimeridian_splitter/geopolygon_utils.py
+++ b/antimeridian_splitter/geopolygon_utils.py
@@ -17,7 +17,7 @@ def check_crossing(lon1: float, lon2: float, validate: bool = True, dlon_thresho
 def translate_polygons(geometry_collection: GeometryCollection, 
                        output_format: str = "geojson") -> Union[List[dict], List[Polygon]]:
     
-  for polygon in geometry_collection:
+  for polygon in geometry_collection.geoms:
       (minx, _, maxx, _) = polygon.bounds
       if minx < -180: geo_polygon = affinity.translate(polygon, xoff = 360)
       elif maxx > 180: geo_polygon = affinity.translate(polygon, xoff = -360)


### PR DESCRIPTION
This pull request fixes the ``ShapelyDeprecationWarning: Iteration over multi-part geometries is deprecated and will be removed in Shapely 2.0. Use the `geoms` property to access the constituent parts of a multi-part geometry.``

More info about the warning: [Migrating to Shapely 1.8 / 2.0](https://shapely.readthedocs.io/en/stable/migration.html#multi-part-geometries-will-no-longer-be-sequences-length-iterable-indexable)