### PR TITLE
Addressing issue #4

### DIFF
--- a/antimeridian_splitter/geopolygon_utils.py
+++ b/antimeridian_splitter/geopolygon_utils.py
@@ -1,8 +1,15 @@
+from enum import Enum
 import json
 from typing import List, Union
 
 from shapely import affinity
 from shapely.geometry import GeometryCollection, Polygon, mapping
+
+
+class OutputFormat(Enum):
+    Geojson = 'geojson'
+    Polygons = 'polygons'
+    GeometryCollection = 'geometrycollection'
 
 
 def check_crossing(lon1: float, lon2: float, validate: bool = True, dlon_threshold: float = 180.0):
@@ -14,13 +21,29 @@ def check_crossing(lon1: float, lon2: float, validate: bool = True, dlon_thresho
         raise ValueError("longitudes must be in degrees [-180.0, 180.0]")   
     return abs(lon2 - lon1) > dlon_threshold
 
-def translate_polygons(geometry_collection: GeometryCollection, 
-                       output_format: str = "geojson") -> Union[List[dict], List[Polygon]]:
-    
-  for polygon in geometry_collection.geoms:
-      (minx, _, maxx, _) = polygon.bounds
-      if minx < -180: geo_polygon = affinity.translate(polygon, xoff = 360)
-      elif maxx > 180: geo_polygon = affinity.translate(polygon, xoff = -360)
-      else: geo_polygon = polygon
 
-      yield json.dumps(mapping(geo_polygon)) if (output_format == "geojson") else geo_polygon
+def translate_polygons(
+    geometry_collection: GeometryCollection,
+    output_format: OutputFormat = OutputFormat.Geojson
+) -> Union[List[dict], List[Polygon], GeometryCollection]:
+
+    geo_polygons = []
+    for polygon in geometry_collection.geoms:
+        (minx, _, maxx, _) = polygon.bounds
+        if minx < -180:
+            geo_polygon = affinity.translate(polygon, xoff = 360)
+        elif maxx > 180:
+            geo_polygon = affinity.translate(polygon, xoff = -360)
+        else:
+            geo_polygon = polygon
+
+        geo_polygons.append(geo_polygon)
+
+    if output_format == OutputFormat.Polygons:
+        result = geo_polygons
+    if output_format == OutputFormat.Geojson:
+        result = [json.dumps(mapping(p)) for p in geo_polygons]
+    elif output_format == OutputFormat.GeometryCollection:
+        result = GeometryCollection(geo_polygons)
+
+    return result

--- a/antimeridian_splitter/split_polygon.py
+++ b/antimeridian_splitter/split_polygon.py
@@ -1,51 +1,32 @@
 import copy
+from functools import reduce
 import math
 from typing import List, Union
+from enum import Enum
+import sys
 
 from shapely.geometry import GeometryCollection, LineString, Polygon
 from shapely.ops import split
 
 # https://gist.github.com/PawaritL/ec7136c0b718ca65db6df1c33fd1bb11
-from .geopolygon_utils import check_crossing, translate_polygons
+from .geopolygon_utils import check_crossing, translate_polygons, OutputFormat
 
 
-def split_polygon(geojson: dict, output_format: str = "geojson") -> Union[
-    List[dict], List[Polygon], GeometryCollection
-    ]:
-    """
-    Given a GeoJSON representation of a Polygon, returns a collection of
-    'antimeridian-safe' constituent polygons split at the 180th meridian, 
-    ensuring compliance with GeoJSON standards (https://tools.ietf.org/html/rfc7946#section-3.1.9)
+class AcceptedGeojsonTypes(Enum):
+    Polygon = 'Polygon'
+    MultiPolygon = 'MultiPolygon'
 
-    Assumptions:
-      - Any two consecutive points with over 180 degrees difference in
-        longitude are assumed to cross the antimeridian
-      - The polygon spans less than 360 degrees in longitude (i.e. does not wrap around the globe)
-      - However, the polygon may cross the antimeridian on multiple occasions
 
-    Parameters:
-        geojson (dict): GeoJSON of input polygon to be split. For example:
-                        {
-                        "type": "Polygon",
-                        "coordinates": [
-                          [
-                            [179.0, 0.0], [-179.0, 0.0], [-179.0, 1.0],
-                            [179.0, 1.0], [179.0, 0.0]
-                          ]
-                        ]
-                        }
-        output_format (str): Available options: "geojson", "polygons", "geometrycollection"
-                             If "geometrycollection" returns a Shapely GeometryCollection.
-                             Otherwise, returns a list of either GeoJSONs or Shapely Polygons
-      
-    Returns:
-        List[dict]/List[Polygon]/GeometryCollection: antimeridian-safe polygon(s)
-    """
-    output_format = output_format.replace("-", "").strip().lower()
-    coords_shift = copy.deepcopy(geojson["coordinates"])
-    shell_minx = shell_maxx = None
+def split_coords(src_coords: List[List[List[float]]]) -> GeometryCollection:
+    coords_shift = copy.deepcopy(src_coords)
+    shell_minx = sys.float_info.max
+    shell_maxx = sys.float_info.min
+
+    # it is possible that the shape provided may be defined as more than 360
+    #   degrees in either direction. Under these circumstances the shifted polygon
+    #   would cross both the 180 and the -180 degree representation of the same
+    #   meridian. This is not allowed, but checked for using the len(split_meriditans)
     split_meridians = set()
-    splitter = None
 
     for ring_index, ring in enumerate(coords_shift):
         if len(ring) < 1: 
@@ -82,20 +63,62 @@ def split_polygon(geojson: dict, output_format: str = "geojson") -> Union[
             if ring_maxx > 180: split_meridians.add(180)
 
     n_splits = len(split_meridians)
-    if n_splits > 1:
+    if n_splits == 0:
+        shell, *holes = src_coords
+        split_polygons = GeometryCollection([Polygon(shell, holes)])
+    elif n_splits == 1:
+        split_lon = split_meridians.pop()
+        meridian = [[split_lon, -90.0], [split_lon, 90.0]]
+        splitter = LineString(meridian)
+
+        shell, *holes = coords_shift
+        split_polygons = split(Polygon(shell, holes), splitter)
+    else:
         raise NotImplementedError(
             """Splitting a Polygon by multiple meridians (MultiLineString) 
                not supported by Shapely"""
         )
-    elif n_splits == 1:
-        split_lon = next(iter(split_meridians))
-        meridian = [[split_lon, -90.0], [split_lon, 90.0]]
-        splitter = LineString(meridian)
+    return split_polygons
 
-    shell, *holes = coords_shift if splitter else geojson["coordinates"]
-    if splitter: split_polygons = split(Polygon(shell, holes), splitter)
-    else: split_polygons = GeometryCollection([Polygon(shell, holes)])
-        
-    geo_polygons = list(translate_polygons(split_polygons, output_format))  
-    if output_format == "geometrycollection": return GeometryCollection(geo_polygons)
-    else: return geo_polygons
+
+def split_polygon(geojson: dict, output_format: OutputFormat = OutputFormat.Geojson) -> Union[
+    List[dict], List[Polygon], GeometryCollection
+]:
+    """
+    Given a GeoJSON representation of a Polygon, returns a collection of
+    'antimeridian-safe' constituent polygons split at the 180th meridian, 
+    ensuring compliance with GeoJSON standards (https://tools.ietf.org/html/rfc7946#section-3.1.9)
+
+    Assumptions:
+      - Any two consecutive points with over 180 degrees difference in
+        longitude are assumed to cross the antimeridian
+      - The polygon spans less than 360 degrees in longitude (i.e. does not wrap around the globe)
+      - However, the polygon may cross the antimeridian on multiple occasions
+
+    Parameters:
+        geojson (dict): GeoJSON of input polygon to be split. For example:
+                {
+                    "type": "Polygon",
+                    "coordinates": [
+                        [
+                            [179.0, 0.0], [-179.0, 0.0], [-179.0, 1.0],
+                            [179.0, 1.0], [179.0, 0.0]
+                        ]
+                    ]
+                }
+        output_format (str): Available options: "geojson", "polygons", "geometrycollection"
+                             If "geometrycollection" returns a Shapely GeometryCollection.
+                             Otherwise, returns a list of either GeoJSONs or Shapely Polygons
+
+    Returns:
+        List[dict]/List[Polygon]/GeometryCollection: antimeridian-safe polygon(s)
+    """
+    geotype = AcceptedGeojsonTypes(geojson['type'])
+    if geotype is AcceptedGeojsonTypes.Polygon:
+        split_polygons = split_coords(geojson['coordinates'])
+    elif geotype is AcceptedGeojsonTypes.MultiPolygon:
+        split_polygons = reduce(
+            GeometryCollection.union,
+            (split_coords(coords) for coords in geojson['coordinates'])
+        )
+    return translate_polygons(split_polygons, output_format)

--- a/antimeridian_splitter/split_polygon_test.py
+++ b/antimeridian_splitter/split_polygon_test.py
@@ -1,5 +1,9 @@
 from .split_polygon import split_polygon
+from .geopolygon_utils import OutputFormat
 import json
+from functools import reduce
+from shapely.geometry.base import BaseGeometry
+import shapely.geometry
 
 example_polygon1 = """
 {
@@ -14,21 +18,58 @@ example_polygon1 = """
 
 def test_split_polygon_to_geometrycollection():
     poly: dict = json.loads(example_polygon1)
-    res = split_polygon(poly, 'geometrycollection')
+    res = split_polygon(poly, OutputFormat.GeometryCollection)
     assert str(res) == 'GEOMETRYCOLLECTION (POLYGON ((180 0, 179 0, 179 1, 180 1, 180 0)), POLYGON ((-180 1, -179 1, -179 0, -180 0, -180 1)))'
 
 def test_split_polygon_to_geojson():
     poly: dict = json.loads(example_polygon1)
-    res = split_polygon(poly, 'geojson')
-    assert len(res) == 2
+    res = split_polygon(poly, OutputFormat.Geojson)
     assert str(res) == """['{"type": "Polygon", "coordinates": [[[180.0, 0.0], [179.0, 0.0], [179.0, 1.0], [180.0, 1.0], [180.0, 0.0]]]}', '{"type": "Polygon", "coordinates": [[[-180.0, 1.0], [-179.0, 1.0], [-179.0, 0.0], [-180.0, 0.0], [-180.0, 1.0]]]}']"""
+    assert len(res) == 2
 
 def test_split_polygon_to_polygons():
     poly: dict = json.loads(example_polygon1)
-    res = split_polygon(poly, 'polygons')
+    res = split_polygon(poly, OutputFormat.GeometryCollection)
     assert len(res) == 2
     string_repr = str([str(poly) for poly in res])
     expect = """['POLYGON ((180 0, 179 0, 179 1, 180 1, 180 0))', 'POLYGON ((-180 1, -179 1, -179 0, -180 0, -180 1))']"""
     assert expect == string_repr
 
+
+example_multipolygon = {
+    'type': 'MultiPolygon',
+    'coordinates': [
+        [
+            [
+                [179.0, 55.0],
+                [179.0, 56.0],
+                [179.0, 56.0],
+                [179.0, 57.0],
+                [179.0, 57.0],
+                [180.0, 58.0],
+                [180.0, 55.0],
+                [179.0, 55.0]
+            ],
+        ],
+        [
+            [
+                [-180.0, 58.0],
+                [-179.0, 58.0],
+                [-175.0, 57.0],
+                [-175.0, 57.0],
+                [-175.0, 56.0],
+                [-176.0, 56.0],
+                [-176.0, 55.0],
+                [-176.0, 55.0],
+                [-180.0, 55.0],
+                [-180.0, 58.0]
+            ],
+        ]
+    ]
+}
+
+def test_split_multipolygons():
+    polygon_collection = split_polygon(example_multipolygon, OutputFormat.Polygons)
+    target_multipolygon = reduce(BaseGeometry.union, polygon_collection)
+    assert json.dumps(example_multipolygon) == json.dumps(shapely.geometry.mapping(target_multipolygon))
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="antimeridian_splitter",
-    version="0.1.0",
+    version="0.2.0",
     author="Pawarit Laosunthara, Alex G Rice",
     author_email="alex@radiant.earth",
     description="Handling problematic real-world geometries (polygons) that cross the antimeridian (aka 180th meridian or International Date Line)",


### PR DESCRIPTION
Addressing Issue #4 

- The use of an `enum.Enum` type of `OutputFormat` to designate return types of `translate_polygons` function
- refactor move functionality of making `GeometryCollections` from `split_polygon` funciton to `translate_polygons`
- added an `enum.Enum` type of `AcceptedGeojsonTypes` that will error out early if an unsupported `geojson` type is attempted to be split
- broke `split_polygon` into `split_polygon` and `split_coords` that operate on the `geojson` and `coords` respectively, so that you can iterate over a `multipolygon`'s collection of `coords`
- slightly different type initialization strategy for `split_coords` function variables
- updated tests and added `multipolygon` tests
- bumped the version number from `0.1.0` to `0.2.0` to indicate breaking changes in how you call the primary function